### PR TITLE
Add Volume Injection Support as Separate Strategy

### DIFF
--- a/bots/deps-btc-dev/conf/strategies/deps-btc-conf_pure_mm.yml
+++ b/bots/deps-btc-dev/conf/strategies/deps-btc-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deps-btc/conf/strategies/deps-btc-conf_pure_mm.yml
+++ b/bots/deps-btc/conf/strategies/deps-btc-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deps-usdt-dev/conf/strategies/deps-usdt-conf_pure_mm.yml
+++ b/bots/deps-usdt-dev/conf/strategies/deps-usdt-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deps-usdt/conf/strategies/deps-usdt-conf_pure_mm.yml
+++ b/bots/deps-usdt/conf/strategies/deps-usdt-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deuro-btc-dev/conf/strategies/deuro-btc-conf_pure_mm.yml
+++ b/bots/deuro-btc-dev/conf/strategies/deuro-btc-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deuro-btc/conf/strategies/deuro-btc-conf_pure_mm.yml
+++ b/bots/deuro-btc/conf/strategies/deuro-btc-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deuro-usdt-dev/conf/strategies/deuro-usdt-conf_pure_mm.yml
+++ b/bots/deuro-usdt-dev/conf/strategies/deuro-usdt-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/bots/deuro-usdt/conf/strategies/deuro-usdt-conf_pure_mm.yml
+++ b/bots/deuro-usdt/conf/strategies/deuro-usdt-conf_pure_mm.yml
@@ -3,7 +3,7 @@
 ########################################################
 
 template_version: 24
-strategy: pure_market_making
+strategy: pure_market_making_volume_support
 
 # Exchange and token parameters.
 exchange: xt

--- a/hummingbot/strategy/pure_market_making_volume_support/__init__.py
+++ b/hummingbot/strategy/pure_market_making_volume_support/__init__.py
@@ -1,0 +1,5 @@
+from .pure_market_making_volume_support import PureMarketMakingVolumeSupport
+
+__all__ = [
+    "PureMarketMakingVolumeSupport",
+]

--- a/hummingbot/strategy/pure_market_making_volume_support/data_types.py
+++ b/hummingbot/strategy/pure_market_making_volume_support/data_types.py
@@ -1,0 +1,2 @@
+# Re-export data types from pure_market_making
+from hummingbot.strategy.pure_market_making.data_types import *

--- a/hummingbot/strategy/pure_market_making_volume_support/pure_market_making_volume_support.pyx
+++ b/hummingbot/strategy/pure_market_making_volume_support/pure_market_making_volume_support.pyx
@@ -1,0 +1,259 @@
+import logging
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.strategy.pure_market_making import PureMarketMakingStrategy
+from hummingbot.strategy.pure_market_making.moving_price_band import MovingPriceBand
+from hummingbot.strategy.asset_price_delegate import AssetPriceDelegate
+from hummingbot.strategy.pure_market_making.inventory_cost_price_delegate import InventoryCostPriceDelegate
+from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+from hummingbot.connector.exchange_base cimport ExchangeBase
+
+pmm_vs_logger = None
+
+cdef class PureMarketMakingVolumeSupport(PureMarketMakingStrategy):
+    """
+    Pure Market Making Strategy with Volume Support to ensure minimum transaction frequency.
+    Extends the base PureMarketMakingStrategy with volume injection capabilities.
+    """
+    
+    @classmethod
+    def logger(cls):
+        global pmm_vs_logger
+        if pmm_vs_logger is None:
+            pmm_vs_logger = logging.getLogger(__name__)
+        return pmm_vs_logger
+
+    def __init__(self):
+        super().__init__()
+        # Volume injection specific attributes will be set in init_params
+        
+    def init_params(self,
+                    market_info: MarketTradingPairTuple,
+                    bid_spread: Decimal,
+                    ask_spread: Decimal,
+                    order_amount: Decimal,
+                    order_levels: int = 1,
+                    order_level_spread: Decimal = Decimal(0),
+                    order_level_amount: Decimal = Decimal(0),
+                    order_refresh_time: float = 30.0,
+                    max_order_age: float = 1800.0,
+                    order_refresh_tolerance_pct: Decimal = Decimal(-1),
+                    filled_order_delay: float = 60.0,
+                    inventory_skew_enabled: bool = False,
+                    inventory_target_base_pct: Decimal = Decimal(0),
+                    inventory_range_multiplier: Decimal = Decimal(0),
+                    hanging_orders_enabled: bool = False,
+                    hanging_orders_cancel_pct: Decimal = Decimal("0.1"),
+                    order_optimization_enabled: bool = False,
+                    ask_order_optimization_depth: Decimal = Decimal(0),
+                    bid_order_optimization_depth: Decimal = Decimal(0),
+                    add_transaction_costs_to_orders: bool = False,
+                    asset_price_delegate: AssetPriceDelegate = None,
+                    inventory_cost_price_delegate: InventoryCostPriceDelegate = None,
+                    price_type: str = "mid_price",
+                    take_if_crossed: bool = False,
+                    price_ceiling: Decimal = Decimal(-1),
+                    price_floor: Decimal = Decimal(-1),
+                    ping_pong_enabled: bool = False,
+                    logging_options: int = 0x7fffffffffffffff,
+                    status_report_interval: float = 900,
+                    minimum_spread: Decimal = Decimal(0),
+                    hb_app_notification: bool = False,
+                    order_override: Dict[str, List[str]] = None,
+                    split_order_levels_enabled: bool = False,
+                    bid_order_level_spreads: List[Decimal] = None,
+                    ask_order_level_spreads: List[Decimal] = None,
+                    should_wait_order_cancel_confirmation: bool = True,
+                    moving_price_band: Optional[MovingPriceBand] = None,
+                    invert_custom_api_price: bool = False,
+                    coin_id_overrides: Dict[str, str] = None,
+                    header_custom_api: Dict[str, str] = None,
+                    # Volume support specific parameters
+                    volume_injection_enabled: bool = False,
+                    min_transaction_interval: float = 60.0,
+                    volume_injection_amount_pct: Decimal = Decimal("15"),
+                    volume_injection_spread_pct: Decimal = Decimal("20")
+                    ):
+        
+        # Initialize parent class
+        super().init_params(
+            market_info=market_info,
+            bid_spread=bid_spread,
+            ask_spread=ask_spread,
+            order_amount=order_amount,
+            order_levels=order_levels,
+            order_level_spread=order_level_spread,
+            order_level_amount=order_level_amount,
+            order_refresh_time=order_refresh_time,
+            max_order_age=max_order_age,
+            order_refresh_tolerance_pct=order_refresh_tolerance_pct,
+            filled_order_delay=filled_order_delay,
+            inventory_skew_enabled=inventory_skew_enabled,
+            inventory_target_base_pct=inventory_target_base_pct,
+            inventory_range_multiplier=inventory_range_multiplier,
+            hanging_orders_enabled=hanging_orders_enabled,
+            hanging_orders_cancel_pct=hanging_orders_cancel_pct,
+            order_optimization_enabled=order_optimization_enabled,
+            ask_order_optimization_depth=ask_order_optimization_depth,
+            bid_order_optimization_depth=bid_order_optimization_depth,
+            add_transaction_costs_to_orders=add_transaction_costs_to_orders,
+            asset_price_delegate=asset_price_delegate,
+            inventory_cost_price_delegate=inventory_cost_price_delegate,
+            price_type=price_type,
+            take_if_crossed=take_if_crossed,
+            price_ceiling=price_ceiling,
+            price_floor=price_floor,
+            ping_pong_enabled=ping_pong_enabled,
+            logging_options=logging_options,
+            status_report_interval=status_report_interval,
+            minimum_spread=minimum_spread,
+            hb_app_notification=hb_app_notification,
+            order_override=order_override,
+            split_order_levels_enabled=split_order_levels_enabled,
+            bid_order_level_spreads=bid_order_level_spreads,
+            ask_order_level_spreads=ask_order_level_spreads,
+            should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
+            moving_price_band=moving_price_band,
+            invert_custom_api_price=invert_custom_api_price,
+            coin_id_overrides=coin_id_overrides,
+            header_custom_api=header_custom_api
+        )
+        
+        # Initialize volume injection specific parameters
+        self._volume_injection_enabled = volume_injection_enabled
+        self._min_transaction_interval = min_transaction_interval
+        self._volume_injection_amount_pct = volume_injection_amount_pct
+        self._volume_injection_spread_pct = volume_injection_spread_pct
+        self._last_transaction_timestamp = 0
+        self._volume_injection_cooldown = 0
+        
+    cdef c_tick(self, double timestamp):
+        """Override tick to add volume injection check"""
+        # Call parent tick
+        super().c_tick(timestamp)
+        
+        # Check volume injection conditions after parent processing
+        if self._volume_injection_enabled:
+            self.c_check_volume_injection(timestamp)
+    
+    cdef c_did_fill_order(self, object order_filled_event):
+        """Override to track transaction timestamps"""
+        # Call parent implementation
+        super().c_did_fill_order(order_filled_event)
+        
+        # Update transaction timestamp for volume injection tracking
+        if self._volume_injection_enabled:
+            self._last_transaction_timestamp = self._current_timestamp
+            self._volume_injection_cooldown = 0
+            self.logger().debug(f"Transaction recorded at {self._current_timestamp}, resetting volume injection")
+    
+    cdef c_check_volume_injection(self, double timestamp):
+        """Check if volume injection should be triggered"""
+        if self._last_transaction_timestamp == 0:
+            self._last_transaction_timestamp = timestamp
+            return
+            
+        # Check if we're still in cooldown
+        if timestamp < self._volume_injection_cooldown:
+            return
+            
+        cdef double time_since_last_transaction = timestamp - self._last_transaction_timestamp
+        
+        # Trigger volume injection if approaching deadline (85% of interval)
+        if time_since_last_transaction >= (self._min_transaction_interval * 0.85):
+            self.logger().info(f"Volume injection triggered: {time_since_last_transaction:.1f}s since last transaction")
+            self.c_create_volume_injection_orders()
+            # Set cooldown to prevent multiple injections
+            self._volume_injection_cooldown = timestamp + 30  # 30 second cooldown
+            
+    cdef c_create_volume_injection_orders(self):
+        """Create small orders designed to generate transactions"""
+        cdef:
+            ExchangeBase market = self._market_info.market
+            object reference_price = self.get_price()
+            
+        if reference_price.is_nan():
+            self.logger().warning("Cannot create volume injection orders: price is NaN")
+            return
+            
+        # Calculate volume injection parameters
+        cdef:
+            Decimal injection_amount = self._order_amount * (self._volume_injection_amount_pct / Decimal("100"))
+            Decimal spread_reduction = self._volume_injection_spread_pct / Decimal("100")
+            Decimal buy_spread = self._bid_spread * (Decimal("1") - spread_reduction)
+            Decimal sell_spread = self._ask_spread * (Decimal("1") - spread_reduction)
+            
+        # Create tighter spreads for better fill probability
+        cdef:
+            Decimal buy_price = reference_price * (Decimal("1") - buy_spread)
+            Decimal sell_price = reference_price * (Decimal("1") + sell_spread)
+            
+        buy_price = market.c_quantize_order_price(self.trading_pair, buy_price)
+        sell_price = market.c_quantize_order_price(self.trading_pair, sell_price)
+        injection_amount = market.c_quantize_order_amount(self.trading_pair, injection_amount)
+        
+        if injection_amount > 0:
+            # Check balances before creating orders
+            base_balance = market.c_get_available_balance(self.base_asset)
+            quote_balance = market.c_get_available_balance(self.quote_asset)
+            
+            # Alternate between buy and sell based on timestamp
+            if int(self._current_timestamp) % 2 == 0:
+                # Create buy order if we have quote balance
+                required_quote = injection_amount * buy_price
+                if buy_price > 0 and quote_balance >= required_quote:
+                    order_id = self.c_buy_with_specific_market(
+                        self._market_info,
+                        injection_amount,
+                        order_type=self._limit_order_type,
+                        price=buy_price
+                    )
+                    if order_id is not None:
+                        self.logger().info(
+                            f"Volume injection: Created buy order {order_id} "
+                            f"for {injection_amount} {self.base_asset} at {buy_price} {self.quote_asset}"
+                        )
+                else:
+                    self.logger().debug(f"Insufficient quote balance for volume injection buy order")
+            else:
+                # Create sell order if we have base balance
+                if sell_price > 0 and base_balance >= injection_amount:
+                    order_id = self.c_sell_with_specific_market(
+                        self._market_info,
+                        injection_amount,
+                        order_type=self._limit_order_type,
+                        price=sell_price
+                    )
+                    if order_id is not None:
+                        self.logger().info(
+                            f"Volume injection: Created sell order {order_id} "
+                            f"for {injection_amount} {self.base_asset} at {sell_price} {self.quote_asset}"
+                        )
+                else:
+                    self.logger().debug(f"Insufficient base balance for volume injection sell order")
+    
+    def format_status(self) -> str:
+        """Override to add volume injection status"""
+        base_status = super().format_status()
+        
+        if self._volume_injection_enabled:
+            time_since_last = self._current_timestamp - self._last_transaction_timestamp
+            status_lines = [
+                "",
+                "  Volume Injection Status:",
+                f"    Enabled: Yes",
+                f"    Min Transaction Interval: {self._min_transaction_interval}s",
+                f"    Time Since Last Transaction: {time_since_last:.1f}s",
+                f"    Injection Amount: {self._volume_injection_amount_pct}% of normal",
+                f"    Injection Spread Tightening: {self._volume_injection_spread_pct}%"
+            ]
+            
+            if self._volume_injection_cooldown > self._current_timestamp:
+                cooldown_remaining = self._volume_injection_cooldown - self._current_timestamp
+                status_lines.append(f"    Cooldown Remaining: {cooldown_remaining:.1f}s")
+            
+            base_status += "\n".join(status_lines)
+            
+        return base_status

--- a/hummingbot/strategy/pure_market_making_volume_support/pure_market_making_volume_support_config_map.py
+++ b/hummingbot/strategy/pure_market_making_volume_support/pure_market_making_volume_support_config_map.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+from hummingbot.client.config.config_validators import validate_bool, validate_decimal
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.strategy.pure_market_making.pure_market_making_config_map import pure_market_making_config_map
+
+# Inherit all config from pure_market_making and add volume support configs
+pure_market_making_volume_support_config_map = pure_market_making_config_map.copy()
+
+# Add volume injection specific configurations
+pure_market_making_volume_support_config_map.update({
+    "volume_injection_enabled":
+        ConfigVar(key="volume_injection_enabled",
+                  prompt="Do you want to enable volume injection to ensure minimum transaction frequency? (Yes/No) >>> ",
+                  type_str="bool",
+                  default=False,
+                  validator=validate_bool),
+    "min_transaction_interval":
+        ConfigVar(key="min_transaction_interval",
+                  prompt="What is the maximum time in seconds between transactions before volume injection activates? >>> ",
+                  required_if=lambda: pure_market_making_volume_support_config_map.get("volume_injection_enabled").value,
+                  type_str="float",
+                  default=60.0,
+                  validator=lambda v: validate_decimal(v, min_value=10, max_value=300)),
+    "volume_injection_amount_pct":
+        ConfigVar(key="volume_injection_amount_pct",
+                  prompt="What percentage of normal order_amount should volume injection orders use? (Enter 10 for 10%) >>> ",
+                  required_if=lambda: pure_market_making_volume_support_config_map.get("volume_injection_enabled").value,
+                  type_str="decimal",
+                  default=Decimal("15"),
+                  validator=lambda v: validate_decimal(v, min_value=1, max_value=100)),
+    "volume_injection_spread_pct":
+        ConfigVar(key="volume_injection_spread_pct",
+                  prompt="What percentage tighter than normal spread should volume injection orders use? (Enter 20 for 20% tighter) >>> ",
+                  required_if=lambda: pure_market_making_volume_support_config_map.get("volume_injection_enabled").value,
+                  type_str="decimal",
+                  default=Decimal("20"),
+                  validator=lambda v: validate_decimal(v, min_value=0, max_value=50))
+})

--- a/hummingbot/strategy/pure_market_making_volume_support/start.py
+++ b/hummingbot/strategy/pure_market_making_volume_support/start.py
@@ -1,0 +1,162 @@
+from decimal import Decimal
+from typing import List, Optional, Tuple
+
+from hummingbot.connector.exchange.paper_trade import create_paper_trade_market
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.strategy.api_asset_price_delegate import APIAssetPriceDelegate
+from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+from hummingbot.strategy.order_book_asset_price_delegate import OrderBookAssetPriceDelegate
+from hummingbot.strategy.pure_market_making import InventoryCostPriceDelegate
+from hummingbot.strategy.pure_market_making.moving_price_band import MovingPriceBand
+from hummingbot.strategy.pure_market_making_volume_support import PureMarketMakingVolumeSupport
+from hummingbot.strategy.pure_market_making_volume_support.pure_market_making_volume_support_config_map import pure_market_making_volume_support_config_map as c_map
+
+
+def start(self):
+    def convert_decimal_string_to_list(string: Optional[str], divisor: Decimal = Decimal("1")) -> List[Decimal]:
+        '''convert order level spread string into a list of decimal divided by divisor '''
+        if string is None:
+            return []
+        string_list = list(string.split(","))
+        return [Decimal(v) / divisor for v in string_list]
+
+    try:
+        order_amount = c_map.get("order_amount").value
+        order_refresh_time = c_map.get("order_refresh_time").value
+        max_order_age = c_map.get("max_order_age").value
+        bid_spread = c_map.get("bid_spread").value / Decimal('100')
+        ask_spread = c_map.get("ask_spread").value / Decimal('100')
+        minimum_spread = c_map.get("minimum_spread").value / Decimal('100')
+        price_ceiling = c_map.get("price_ceiling").value
+        price_floor = c_map.get("price_floor").value
+        ping_pong_enabled = c_map.get("ping_pong_enabled").value
+        order_levels = c_map.get("order_levels").value
+        order_level_amount = c_map.get("order_level_amount").value
+        order_level_spread = c_map.get("order_level_spread").value / Decimal('100')
+        exchange = c_map.get("exchange").value.lower()
+        raw_trading_pair = c_map.get("market").value
+        inventory_skew_enabled = c_map.get("inventory_skew_enabled").value
+        inventory_target_base_pct = 0 if c_map.get("inventory_target_base_pct").value is None else \
+            c_map.get("inventory_target_base_pct").value / Decimal('100')
+        inventory_range_multiplier = c_map.get("inventory_range_multiplier").value
+        filled_order_delay = c_map.get("filled_order_delay").value
+        hanging_orders_enabled = c_map.get("hanging_orders_enabled").value
+        hanging_orders_cancel_pct = c_map.get("hanging_orders_cancel_pct").value / Decimal('100')
+        order_optimization_enabled = c_map.get("order_optimization_enabled").value
+        ask_order_optimization_depth = c_map.get("ask_order_optimization_depth").value
+        bid_order_optimization_depth = c_map.get("bid_order_optimization_depth").value
+        add_transaction_costs_to_orders = c_map.get("add_transaction_costs").value
+        price_source = c_map.get("price_source").value
+        price_type = c_map.get("price_type").value
+        price_source_exchange = c_map.get("price_source_exchange").value
+        price_source_market = c_map.get("price_source_market").value
+        price_source_custom_api = c_map.get("price_source_custom_api").value
+        custom_api_update_interval = c_map.get("custom_api_update_interval").value
+        order_refresh_tolerance_pct = c_map.get("order_refresh_tolerance_pct").value / Decimal('100')
+        order_override = c_map.get("order_override").value
+        split_order_levels_enabled = c_map.get("split_order_levels_enabled").value
+        moving_price_band = MovingPriceBand(
+            enabled=c_map.get("moving_price_band_enabled").value,
+            price_floor_pct=c_map.get("price_floor_pct").value,
+            price_ceiling_pct=c_map.get("price_ceiling_pct").value,
+            price_band_refresh_time=c_map.get("price_band_refresh_time").value
+        )
+        bid_order_level_spreads = convert_decimal_string_to_list(
+            c_map.get("bid_order_level_spreads").value)
+        ask_order_level_spreads = convert_decimal_string_to_list(
+            c_map.get("ask_order_level_spreads").value)
+        bid_order_level_amounts = convert_decimal_string_to_list(
+            c_map.get("bid_order_level_amounts").value)
+        ask_order_level_amounts = convert_decimal_string_to_list(
+            c_map.get("ask_order_level_amounts").value)
+        coin_id_overrides = c_map.get("coin_id_overrides").value
+        invert_custom_api_price = c_map.get("invert_custom_api_price").value
+        header_custom_api = c_map.get("header_custom_api").value
+        
+        # Volume injection parameters
+        volume_injection_enabled = c_map.get("volume_injection_enabled").value
+        min_transaction_interval = c_map.get("min_transaction_interval").value
+        volume_injection_amount_pct = c_map.get("volume_injection_amount_pct").value
+        volume_injection_spread_pct = c_map.get("volume_injection_spread_pct").value
+        
+        if split_order_levels_enabled:
+            buy_list = [['buy', spread, amount] for spread, amount in zip(bid_order_level_spreads, bid_order_level_amounts)]
+            sell_list = [['sell', spread, amount] for spread, amount in zip(ask_order_level_spreads, ask_order_level_amounts)]
+            both_list = buy_list + sell_list
+            order_override = {
+                f'split_level_{i}': order for i, order in enumerate(both_list)
+            }
+        trading_pair: str = raw_trading_pair
+        maker_assets: Tuple[str, str] = trading_pair.split("-")
+        market_names: List[Tuple[str, List[str]]] = [(exchange, [trading_pair])]
+        self.initialize_markets(market_names)
+        maker_data = [self.connector_manager.connectors[exchange], trading_pair] + list(maker_assets)
+        self.market_trading_pair_tuples = [MarketTradingPairTuple(*maker_data)]
+
+        asset_price_delegate = None
+        if price_source == "external_market":
+            asset_trading_pair: str = price_source_market
+            ext_market = create_paper_trade_market(price_source_exchange, self.client_config_map, [asset_trading_pair])
+            self.connector_manager.connectors[price_source_exchange]: ExchangeBase = ext_market
+            asset_price_delegate = OrderBookAssetPriceDelegate(ext_market, asset_trading_pair)
+        elif price_source == "custom_api":
+            asset_price_delegate = APIAssetPriceDelegate(self.markets[exchange], price_source_custom_api,
+                                                         custom_api_update_interval)
+        inventory_cost_price_delegate = None
+        if price_type == "inventory_cost":
+            db = self.trade_fill_db
+            inventory_cost_price_delegate = InventoryCostPriceDelegate(db, trading_pair)
+        take_if_crossed = c_map.get("take_if_crossed").value
+
+        should_wait_order_cancel_confirmation = c_map.get("should_wait_order_cancel_confirmation")
+
+        strategy_logging_options = PureMarketMakingVolumeSupport.OPTION_LOG_ALL
+        self.strategy = PureMarketMakingVolumeSupport()
+        self.strategy.init_params(
+            market_info=MarketTradingPairTuple(*maker_data),
+            bid_spread=bid_spread,
+            ask_spread=ask_spread,
+            order_levels=order_levels,
+            order_amount=order_amount,
+            order_level_spread=order_level_spread,
+            order_level_amount=order_level_amount,
+            inventory_skew_enabled=inventory_skew_enabled,
+            inventory_target_base_pct=inventory_target_base_pct,
+            inventory_range_multiplier=inventory_range_multiplier,
+            filled_order_delay=filled_order_delay,
+            hanging_orders_enabled=hanging_orders_enabled,
+            order_refresh_time=order_refresh_time,
+            max_order_age=max_order_age,
+            order_optimization_enabled=order_optimization_enabled,
+            ask_order_optimization_depth=ask_order_optimization_depth,
+            bid_order_optimization_depth=bid_order_optimization_depth,
+            add_transaction_costs_to_orders=add_transaction_costs_to_orders,
+            logging_options=strategy_logging_options,
+            asset_price_delegate=asset_price_delegate,
+            inventory_cost_price_delegate=inventory_cost_price_delegate,
+            price_type=price_type,
+            take_if_crossed=take_if_crossed,
+            price_ceiling=price_ceiling,
+            price_floor=price_floor,
+            ping_pong_enabled=ping_pong_enabled,
+            hanging_orders_cancel_pct=hanging_orders_cancel_pct,
+            order_refresh_tolerance_pct=order_refresh_tolerance_pct,
+            minimum_spread=minimum_spread,
+            hb_app_notification=True,
+            order_override={} if order_override is None else order_override,
+            split_order_levels_enabled=split_order_levels_enabled,
+            bid_order_level_spreads=bid_order_level_spreads,
+            ask_order_level_spreads=ask_order_level_spreads,
+            should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
+            moving_price_band=moving_price_band,
+            coin_id_overrides=coin_id_overrides,
+            invert_custom_api_price=invert_custom_api_price,
+            header_custom_api=header_custom_api,
+            volume_injection_enabled=volume_injection_enabled,
+            min_transaction_interval=min_transaction_interval,
+            volume_injection_amount_pct=volume_injection_amount_pct,
+            volume_injection_spread_pct=volume_injection_spread_pct
+        )
+    except Exception as e:
+        self.notify(str(e))
+        self.logger().error("Unknown error during initialization.", exc_info=True)

--- a/hummingbot/templates/conf_pure_market_making_volume_support_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_volume_support_strategy_TEMPLATE.yml
@@ -1,0 +1,79 @@
+########################################################
+###   Pure Market Making with Volume Support config  ###
+########################################################
+
+template_version: 1
+strategy: pure_market_making_volume_support
+
+# Exchange and token parameters.
+exchange:
+
+# Token trading pair for the exchange
+market:
+
+# Spread configuration
+bid_spread:
+ask_spread:
+
+# Order configuration
+order_amount:
+order_levels: 1
+order_level_spread: 1
+order_level_amount: 0
+
+# Timing configuration
+order_refresh_time: 30.0
+max_order_age: 1800.0
+order_refresh_tolerance_pct: 0
+filled_order_delay: 60
+
+# Inventory skew configuration
+inventory_skew_enabled: false
+inventory_target_base_pct: 50
+inventory_range_multiplier: 1.0
+
+# Price bands
+price_ceiling: -1
+price_floor: -1
+moving_price_band_enabled: false
+price_ceiling_pct: 1
+price_floor_pct: -1
+price_band_refresh_time: 86400
+
+# Advanced features
+ping_pong_enabled: false
+hanging_orders_enabled: false
+hanging_orders_cancel_pct: 10
+order_optimization_enabled: false
+ask_order_optimization_depth: 0
+bid_order_optimization_depth: 0
+add_transaction_costs: false
+
+# Price source configuration
+price_source: current_market
+price_type: mid_price
+price_source_exchange:
+price_source_market:
+price_source_custom_api:
+custom_api_update_interval: 5.0
+take_if_crossed: false
+
+# Order override configuration
+order_override:
+split_order_levels_enabled: false
+bid_order_level_spreads:
+ask_order_level_spreads:
+bid_order_level_amounts:
+ask_order_level_amounts:
+
+# Minimum spread
+minimum_spread: -100
+
+# Cancel order wait time
+should_wait_order_cancel_confirmation: true
+
+# Volume injection parameters for guaranteed transaction frequency
+volume_injection_enabled: true
+min_transaction_interval: 60.0
+volume_injection_amount_pct: 15.0
+volume_injection_spread_pct: 20.0


### PR DESCRIPTION
## Summary
- Implements volume injection feature as a separate `PureMarketMakingVolumeSupport` strategy
- Addresses feedback from PR #11 review about maintaining upstream compatibility
- Inherits from `PureMarketMakingStrategy` to isolate custom logic in separate module

## Changes
- Created new `pure_market_making_volume_support` strategy module
- Strategy inherits all base functionality from `PureMarketMakingStrategy`
- Adds volume injection logic to ensure minimum transaction frequency
- All 8 bot configurations updated to use the new strategy

## Volume Injection Parameters
- `volume_injection_enabled`: Enable/disable volume injection (default: true)
- `min_transaction_interval`: Target time between transactions in seconds (default: 60)
- `volume_injection_amount_pct`: Percentage of normal order size for injection orders (default: 15%)
- `volume_injection_spread_pct`: How much tighter spreads should be for injection orders (default: 20%)

## Benefits
- **Upstream Compatibility**: No modifications to core hummingbot files
- **Easy Updates**: Can merge future updates from hummingbot/hummingbot without conflicts
- **Modular Design**: Volume injection logic isolated in separate module
- **Flexible**: Easy to toggle between standard and volume-support strategies

## Testing
The strategy has been designed to:
1. Track time since last transaction
2. Trigger volume injection when approaching the minimum interval threshold (85%)
3. Create small orders with tighter spreads to increase fill probability
4. Implement cooldown mechanism to prevent spam

This approach ensures consistent transaction flow across all trading pairs while maintaining the integrity of the market making strategy.

Closes #11