### PR TITLE
Add fixed price source for custom market making

### DIFF
--- a/.github/workflows/hummingbot-dev.yaml
+++ b/.github/workflows/hummingbot-dev.yaml
@@ -8,6 +8,7 @@ on:
 env:
   CRYPTO_PAIR_01: deuro-usdt
   CRYPTO_PAIR_02: deps-usdt
+  CRYPTO_PAIR_03: jusd-usdt
   DOCKER_TAGS: dfxswiss/hummingbot:beta
   AZURE_RESOURCE_GROUP: rg-dfx-api-dev
   AZURE_STORAGE_ACCOUNT_NAME: stdfxapidev
@@ -96,21 +97,38 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Render deployment YAML for CRYPTO_PAIR_03
+        uses: nowactions/envsubst@v1
+        with:
+          input: ./aci-dev.yaml
+          output: ./rendered-aci-${{ env.CRYPTO_PAIR_03 }}-dev.yaml
+        env:
+          CRYPTO_PAIR:  ${{ env.CRYPTO_PAIR_03 }}
+          DEPLOY_INFO: ${{ env.DEPLOY_INFO }}
+          STORAGE_KEY: ${{ env.STORAGE_KEY }}
+          LOG_WORKSPACE_ID: ${{ env.LOG_WORKSPACE_ID }}
+          LOG_WORKSPACE_KEY: ${{ env.LOG_WORKSPACE_KEY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Stop Azure Container Instance
         run: |
           az container stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ci-dfx-hb-${{ env.CRYPTO_PAIR_01 }}-dev
           az container stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ci-dfx-hb-${{ env.CRYPTO_PAIR_02 }}-dev
+          az container stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ci-dfx-hb-${{ env.CRYPTO_PAIR_03 }}-dev
 
       - name: Delete Azure Container Instance
         run: |
           az container delete --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ci-dfx-hb-${{ env.CRYPTO_PAIR_01 }}-dev --yes
           az container delete --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ci-dfx-hb-${{ env.CRYPTO_PAIR_02 }}-dev --yes
+          az container delete --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ci-dfx-hb-${{ env.CRYPTO_PAIR_03 }}-dev --yes
 
       - name: Deploy container instance
         run: |
           az container create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --file ./rendered-aci-${{ env.CRYPTO_PAIR_01 }}-dev.yaml
           az container create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --file ./rendered-aci-${{ env.CRYPTO_PAIR_02 }}-dev.yaml
-
+          az container create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --file ./rendered-aci-${{ env.CRYPTO_PAIR_03 }}-dev.yaml
+          
       - name: Logout from Azure
         run: |
           az logout

--- a/bots/jusd-usdt-dev/conf/conf_client.yml
+++ b/bots/jusd-usdt-dev/conf/conf_client.yml
@@ -1,0 +1,177 @@
+####################################
+###   client_config_map config   ###
+####################################
+
+instance_id: a57bd662c55117ca52381a128ae008bb1138369f
+
+# Fetch trading pairs from all exchanges if True, otherwise fetch only from connected exchanges.
+fetch_pairs_from_all_exchanges: false
+
+log_level: INFO
+
+debug_console: false
+
+strategy_report_interval: 900.0
+
+logger_override_whitelist:
+- hummingbot.strategy.arbitrage
+- hummingbot.strategy.cross_exchange_market_making
+- conf
+
+log_file_path: /home/hummingbot/logs
+
+kill_switch_mode: {}
+
+# What to auto-fill in the prompt after each import command (start/config)
+autofill_import: disabled
+
+# MQTT Bridge configuration.
+mqtt_bridge:
+  mqtt_host: localhost
+  mqtt_port: 1883
+  mqtt_username: ''
+  mqtt_password: ''
+  mqtt_namespace: hbot
+  mqtt_ssl: false
+  mqtt_logger: true
+  mqtt_notifier: true
+  mqtt_commands: true
+  mqtt_events: true
+  mqtt_external_events: true
+  mqtt_autostart: false
+
+# Error log sharing
+send_error_logs: true
+
+# Advanced database options, currently supports SQLAlchemy's included dialects
+# Reference: https://docs.sqlalchemy.org/en/13/dialects/
+# To use an instance of SQLite DB the required configuration is 
+#   db_engine: sqlite
+# To use a DBMS the required configuration is
+#   db_host: 127.0.0.1
+#   db_port: 3306
+#   db_username: username
+#   db_password: password
+#   db_name: dbname
+db_mode:
+  db_engine: sqlite
+
+# Balance Limit Configurations
+# e.g. Setting USDT and BTC limits on Binance.
+# balance_asset_limit:
+#   binance:
+#     BTC: 0.1
+#     USDT: 1000
+balance_asset_limit:
+  bing_x: {}
+  dexalot: {}
+  coinbase_advanced_trade: {}
+  derive: {}
+  gate_io: {}
+  kucoin: {}
+  mexc: {}
+  derive_testnet: {}
+  okx: {}
+  ndax: {}
+  xrpl: {}
+  kucoin_hft: {}
+  vertex: {}
+  binance: {}
+  dexalot_testnet: {}
+  bybit: {}
+  htx: {}
+  hyperliquid: {}
+  ascend_ex: {}
+  btc_markets: {}
+  binance_us: {}
+  bitmart: {}
+  kraken: {}
+  xt: {}
+  bybit_testnet: {}
+  injective_v2: {}
+  ndax_testnet: {}
+  cube: {}
+  hyperliquid_testnet: {}
+  bitstamp: {}
+  vertex_testnet: {}
+  bitrue: {}
+
+# Fixed gas price (in Gwei) for Ethereum transactions
+manual_gas_price: 50.0
+
+# Gateway API Configurations
+# default host to only use localhost
+# Port need to match the final installation port for Gateway
+gateway:
+  gateway_api_host: localhost
+  gateway_api_port: '15888'
+
+certs_path: /home/hummingbot/certs
+
+# Whether to enable aggregated order and trade data collection
+anonymized_metrics_mode:
+  anonymized_metrics_interval_min: 15.0
+
+# A source for rate oracle, currently ascend_ex, binance, binance_us, coin_gecko, coin_cap, dexalot, kucoin, gate_io, coinbase_advanced_trade, cube, hyperliquid, derive, mexc
+rate_oracle_source:
+  name: binance
+
+# A universal token which to display tokens values in, e.g. USD,EUR,BTC
+global_token:
+  global_token_name: USDT
+  global_token_symbol: $
+
+# Percentage of API rate limits (on any exchange and any end point) allocated to this bot instance.
+# Enter 50 to indicate 50%. E.g. if the API rate limit is 100 calls per second, and you allocate 
+# 50% to this setting, the bot will have a maximum (limit) of 50 calls per second
+rate_limits_share_pct: 100.0
+
+commands_timeout:
+  create_command_timeout: 10.0
+  other_commands_timeout: 30.0
+
+# Tabulate table format style (https://github.com/astanin/python-tabulate#table-format)
+tables_format: psql
+
+paper_trade:
+  paper_trade_exchanges:
+  - binance
+  - kucoin
+  - kraken
+  - gate_io
+  paper_trade_account_balance:
+    BTC: 1.0
+    USDT: 100000.0
+    USDC: 100000.0
+    ETH: 20.0
+    WETH: 20.0
+    SOL: 100.0
+    DOGE: 1000000.0
+    HBOT: 10000000.0
+
+color:
+  top_pane: '#000000'
+  bottom_pane: '#000000'
+  output_pane: '#262626'
+  input_pane: '#1C1C1C'
+  logs_pane: '#121212'
+  terminal_primary: '#5FFFD7'
+  primary_label: '#5FFFD7'
+  secondary_label: '#FFFFFF'
+  success_label: '#5FFFD7'
+  warning_label: '#FFFF00'
+  info_label: '#5FD7FF'
+  error_label: '#FF0000'
+  gold_label: '#FFD700'
+  silver_label: '#C0C0C0'
+  bronze_label: '#CD7F32'
+
+# The tick size is the frequency with which the clock notifies the time iterators by calling the
+# c_tick() method, that means for example that if the tick size is 1, the logic of the strategy 
+# will run every second.
+tick_size: 1.0
+
+market_data_collection:
+  market_data_collection_enabled: false
+  market_data_collection_interval: 60
+  market_data_collection_depth: 20

--- a/bots/jusd-usdt-dev/conf/strategies/jusd-usdt-conf_pure_mm.yml
+++ b/bots/jusd-usdt-dev/conf/strategies/jusd-usdt-conf_pure_mm.yml
@@ -1,159 +1,162 @@
 ########################################################
-###       Custom market making strategy config       ###
+###       Pure market making strategy config         ###
 ########################################################
 
 template_version: 24
 strategy: custom_market_making
 
 # Exchange and token parameters.
-exchange: null
+exchange: xt
 
-# Token trading pair for the exchange, e.g. BTC-USDT
-market: null
+# Token trading pair for the exchange
+market: DEPS-USDT ## IMPORTANT TODO: change to JUSD-USDT
 
 # How far away from mid price to place the bid order.
 # Spread of 1 = 1% away from mid price at that time.
 # Example if mid price is 100 and bid_spread is 1.
 # Your bid is placed at 99.
-bid_spread: null
+bid_spread: 5 ## IMPORTANT TODO: change to 0.1
 
 # How far away from mid price to place the ask order.
 # Spread of 1 = 1% away from mid price at that time.
 # Example if mid price is 100 and ask_spread is 1.
 # Your bid is placed at 101.
-ask_spread: null
+ask_spread: 5 ## IMPORTANT TODO: change to 0.1
 
 # Minimum Spread
-# How far away from the mid price to cancel active orders
-minimum_spread: null
+# How far away from the mid price to cancel active orders (-100 deactivated)
+minimum_spread: 0.002 ## IMPORTANT TODO: change to 0.001
 
 # Time in seconds before cancelling and placing new orders.
 # If the value is 60, the bot cancels active orders and placing new ones after a minute.
-order_refresh_time: null
+order_refresh_time: 10
 
 # Time in seconds before replacing existing order with new orders at the same price.
-max_order_age: null
+max_order_age: 86400.0
 
 # The spread (from mid price) to defer order refresh process to the next cycle.
 # (Enter 1 to indicate 1%), value below 0, e.g. -1, is to disable this feature - not recommended.
-order_refresh_tolerance_pct: null
+order_refresh_tolerance_pct: 0.21 ## IMPORTANT TODO: change to 0.1
 
 # Size of your bid and ask order.
-order_amount: null
+order_amount: 300 ## IMPORTANT TODO: review technical requirements
 
 # Price band ceiling.
-price_ceiling: null
+price_ceiling: -1.0
 
 # Price band floor.
-price_floor: null
+price_floor: -1.0
 
 # enable moving price floor and ceiling.
-moving_price_band_enabled: null
+moving_price_band_enabled: false
 
 # Price band ceiling pct.
-price_ceiling_pct: null
+price_ceiling_pct: 1.0
 
 # Price band floor pct.
-price_floor_pct: null
+price_floor_pct: -1.0
 
 # price_band_refresh_time.
-price_band_refresh_time: null
+price_band_refresh_time: 86400
 
 # Whether to alternate between buys and sells (true/false).
-ping_pong_enabled: null
+ping_pong_enabled: false
 
 # Whether to enable Inventory skew feature (true/false).
-inventory_skew_enabled: null
+inventory_skew_enabled: false
 
 # Target base asset inventory percentage target to be maintained (for Inventory skew feature).
-inventory_target_base_pct: null
+inventory_target_base_pct: 50.0
 
 # The range around the inventory target base percent to maintain, expressed in multiples of total order size (for
 # inventory skew feature).
-inventory_range_multiplier: null
+inventory_range_multiplier: 1.0
 
 # Initial price of the base asset. Note: this setting is not affects anything, the price is kept in the database.
-inventory_price: null
+inventory_price: 1.0
 
 # Number of levels of orders to place on each side of the order book.
-order_levels: null
+order_levels: 61
 
 # Increase or decrease size of consecutive orders after the first order (if order_levels > 1).
-order_level_amount: null
+order_level_amount: 0
 
 # Order price space between orders (if order_levels > 1).
-order_level_spread: null
+order_level_spread: 0.035
 
 # How long to wait before placing the next order in case your order gets filled.
-filled_order_delay: null
+filled_order_delay: 1
 
 # Whether to stop cancellations of orders on the other side (of the order book),
 # when one side is filled (hanging orders feature) (true/false).
-hanging_orders_enabled: null
+hanging_orders_enabled: false
 
 # Spread (from mid price, in percentage) hanging orders will be canceled (Enter 1 to indicate 1%)
-hanging_orders_cancel_pct: null
+hanging_orders_cancel_pct: 2.0
 
 # Whether to enable order optimization mode (true/false).
-order_optimization_enabled: null
+order_optimization_enabled: false
 
 # The depth in base asset amount to be used for finding top ask (for order optimization mode).
-ask_order_optimization_depth: null
+ask_order_optimization_depth: 0
 
 # The depth in base asset amount to be used for finding top bid (for order optimization mode).
-bid_order_optimization_depth: null
+bid_order_optimization_depth: 0
 
 # Whether to enable adding transaction costs to order price calculation (true/false).
-add_transaction_costs: null
+add_transaction_costs: false
 
 # The price source (current_market/external_market/custom_api/fixed_price).
-price_source: null
+price_source: fixed_price
 
 # The price type (mid_price/last_price/last_own_trade_price/best_bid/best_ask/inventory_cost).
-price_type: null
+price_type:
 
 # An external exchange name (for external exchange pricing source).
-price_source_exchange: null
+price_source_exchange:
 
 # A trading pair for the external exchange, e.g. BTC-USDT (for external exchange pricing source).
-price_source_market: null
+price_source_market:
 
 # An external api that returns price (for custom_api pricing source).
-price_source_custom_api: null
+price_source_custom_api: 
 
 # A fixed hardcoded price (for fixed_price pricing source).
-price_source_fixed_price: null
+price_source_fixed_price: 0.01905 ## IMPORTANT TODO: change to 1 JUSD-USDT
 
-# An interval time in second to update the price from custom api (for custom_api pricing source).
-custom_api_update_interval: null
-
-#Take order if they cross order book when external price source is enabled
-take_if_crossed: null
-
-# Use user provided orders to directly override the orders placed by order_amount and order_level_parameter
-# This is an advanced feature and user is expected to directly edit this field in config file
-# Below is an sample input, the format is a dictionary, the key is user-defined order name, the value is a list which includes buy/sell, order spread, and order amount
-# order_override:
-#   order_1: [buy, 0.5, 100]
-#   order_2: [buy, 0.75, 200]
-#   order_3: [sell, 0.1, 500]
-# Please make sure there is a space between : and [
-order_override: null
-
-# Simpler override config for separate bid and order level spreads
-split_order_levels_enabled: null
-bid_order_level_spreads: null
-ask_order_level_spreads: null
-bid_order_level_amounts: null
-ask_order_level_amounts: null
-# If the strategy should wait to receive cancellations confirmation before creating new orders during refresh time
-should_wait_order_cancel_confirmation: True
-
-# CoinGecko coin ID overrides for rate oracle
-coin_id_overrides: {}
-
-# Invert custom API price
+# Invert custom api price
 invert_custom_api_price: false
 
-# Custom API headers
-header_custom_api: {}
+# An interval time in second to update the price from custom api (for custom_api pricing source).
+custom_api_update_interval: 10.0
+
+#Take order if they cross order book when external price source is enabled
+take_if_crossed: true
+
+# Simpler override config for separate bid and order level spreads
+split_order_levels_enabled: false
+bid_order_level_spreads:
+ask_order_level_spreads:
+bid_order_level_amounts:
+ask_order_level_amounts:
+
+# If the strategy should wait to receive cancellations confirmation before creating new orders during refresh time
+should_wait_order_cancel_confirmation: true
+
+# Use CoinGecko as rate oracle source
+rate_oracle_source: coin_gecko
+
+# Token mapping to CoinGecko IDs
+coin_id_overrides:
+  deuro: decentralized-euro
+  DEURO: decentralized-euro
+  usdt: tether
+  USDT: tether
+  eur: eur
+  EUR: eur
+  deps: native-decentralized-euro-protocol-share
+  DEPS: native-decentralized-euro-protocol-share
+  ndeps: native-decentralized-euro-protocol-share
+  NDEPS: native-decentralized-euro-protocol-share
+  USD: usd
+  usd: usd

--- a/hummingbot/strategy/custom_market_making/custom_market_making_config_map.py
+++ b/hummingbot/strategy/custom_market_making/custom_market_making_config_map.py
@@ -34,7 +34,7 @@ def order_amount_prompt() -> str:
 
 
 def validate_price_source(value: str) -> Optional[str]:
-    if value not in {"current_market", "external_market", "custom_api"}:
+    if value not in {"current_market", "external_market", "custom_api", "fixed_price"}:
         return "Invalid price source type."
 
 
@@ -45,7 +45,9 @@ def on_validate_price_source(value: str):
         custom_market_making_config_map["take_if_crossed"].value = None
     if value != "custom_api":
         custom_market_making_config_map["price_source_custom_api"].value = None
-    else:
+    if value != "fixed_price":
+        custom_market_making_config_map["price_source_fixed_price"].value = None
+    if value == "custom_api":
         custom_market_making_config_map["price_type"].value = "custom"
 
 
@@ -82,7 +84,7 @@ def validate_price_floor_ceiling(value: str) -> Optional[str]:
 def validate_price_type(value: str) -> Optional[str]:
     error = None
     price_source = custom_market_making_config_map.get("price_source").value
-    if price_source != "custom_api":
+    if price_source not in {"custom_api", "fixed_price"}:
         valid_values = {"mid_price",
                         "last_price",
                         "last_own_trade_price",
@@ -92,7 +94,7 @@ def validate_price_type(value: str) -> Optional[str]:
                         }
         if value not in valid_values:
             error = "Invalid price type."
-    elif value != "custom":
+    elif value not in {None, "", "custom"}:
         error = "Invalid price type."
     return error
 
@@ -333,7 +335,7 @@ custom_market_making_config_map = {
                   validator=validate_bool),
     "price_source":
         ConfigVar(key="price_source",
-                  prompt="Which price source to use? (current_market/external_market/custom_api) >>> ",
+                  prompt="Which price source to use? (current_market/external_market/custom_api/fixed_price) >>> ",
                   type_str="str",
                   default="current_market",
                   validator=validate_price_source,
@@ -343,7 +345,7 @@ custom_market_making_config_map = {
                   prompt="Which price type to use? ("
                          "mid_price/last_price/last_own_trade_price/best_bid/best_ask/inventory_cost) >>> ",
                   type_str="str",
-                  required_if=lambda: custom_market_making_config_map.get("price_source").value != "custom_api",
+                  required_if=lambda: custom_market_making_config_map.get("price_source").value not in {"custom_api", "fixed_price"},
                   default="mid_price",
                   on_validated=on_validated_price_type,
                   validator=validate_price_type),
@@ -372,6 +374,12 @@ custom_market_making_config_map = {
                   prompt="Enter pricing API URL >>> ",
                   required_if=lambda: custom_market_making_config_map.get("price_source").value == "custom_api",
                   type_str="str"),
+    "price_source_fixed_price":
+        ConfigVar(key="price_source_fixed_price",
+                  prompt="Enter fixed price >>> ",
+                  required_if=lambda: custom_market_making_config_map.get("price_source").value == "fixed_price",
+                  type_str="decimal",
+                  validator=lambda v: validate_decimal(v, min_value=Decimal("0"), inclusive=False)),
     "custom_api_update_interval":
         ConfigVar(key="custom_api_update_interval",
                   prompt="Enter custom API update interval in second (default: 5.0, min: 0.5) >>> ",

--- a/hummingbot/strategy/custom_market_making/start.py
+++ b/hummingbot/strategy/custom_market_making/start.py
@@ -8,6 +8,7 @@ from hummingbot.strategy.custom_market_making import CustomMarketMakingStrategy,
 from hummingbot.strategy.custom_market_making.custom_market_making_config_map import (
     custom_market_making_config_map as c_map,
 )
+from hummingbot.strategy.fixed_asset_price_delegate import FixedAssetPriceDelegate
 from hummingbot.strategy.custom_market_making.moving_price_band import MovingPriceBand
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.order_book_asset_price_delegate import OrderBookAssetPriceDelegate
@@ -52,6 +53,7 @@ def start(self):
         price_source_exchange = c_map.get("price_source_exchange").value
         price_source_market = c_map.get("price_source_market").value
         price_source_custom_api = c_map.get("price_source_custom_api").value
+        price_source_fixed_price = c_map.get("price_source_fixed_price").value
         custom_api_update_interval = c_map.get("custom_api_update_interval").value
         order_refresh_tolerance_pct = c_map.get("order_refresh_tolerance_pct").value / Decimal('100')
         order_override = c_map.get("order_override").value
@@ -96,6 +98,8 @@ def start(self):
         elif price_source == "custom_api":
             asset_price_delegate = APIAssetPriceDelegate(self.markets[exchange], price_source_custom_api,
                                                          custom_api_update_interval)
+        elif price_source == "fixed_price":
+            asset_price_delegate = FixedAssetPriceDelegate(self.markets[exchange], price_source_fixed_price)
         inventory_cost_price_delegate = None
         if price_type == "inventory_cost":
             db = self.trade_fill_db

--- a/hummingbot/strategy/fixed_asset_price_delegate.pxd
+++ b/hummingbot/strategy/fixed_asset_price_delegate.pxd
@@ -1,0 +1,7 @@
+from hummingbot.connector.exchange_base cimport ExchangeBase
+from .asset_price_delegate cimport AssetPriceDelegate
+
+cdef class FixedAssetPriceDelegate(AssetPriceDelegate):
+    cdef:
+        ExchangeBase _market
+        object _fixed_price

--- a/hummingbot/strategy/fixed_asset_price_delegate.pyx
+++ b/hummingbot/strategy/fixed_asset_price_delegate.pyx
@@ -1,0 +1,26 @@
+from decimal import Decimal
+
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.core.data_type.common import PriceType
+from .asset_price_delegate cimport AssetPriceDelegate
+
+
+cdef class FixedAssetPriceDelegate(AssetPriceDelegate):
+    def __init__(self, market: ExchangeBase, fixed_price: Decimal):
+        super().__init__()
+        self._market = market
+        self._fixed_price = fixed_price
+
+    def get_price_by_type(self, _: PriceType) -> Decimal:
+        return self.c_get_mid_price()
+
+    cdef object c_get_mid_price(self):
+        return self._fixed_price
+
+    @property
+    def ready(self) -> bool:
+        return True
+
+    @property
+    def market(self) -> ExchangeBase:
+        return self._market


### PR DESCRIPTION
## Summary
- Add a new `fixed_price` option to `custom_market_making` price source handling and wire it in strategy startup.
- Introduce `price_source_fixed_price` config and a new fixed-price asset delegate that always returns the configured hardcoded price.
- Update the custom MM template and add a `jusd-usdt-dev` strategy config that uses `price_source: fixed_price`.

## Test plan
- [x] Build image with `./scripts/build_release_image.sh local/hummingbot v1`
- [x] Start `jusd-usdt-dev` bot with docker-compose using the new image
- [x] Verify runtime behavior from logs: no custom API fetches in latest run and order prices centered around `0.01905`
- [x] Confirm config inside container has `price_source: fixed_price` and `price_source_fixed_price: 0.01905`