### PR TITLE
Set JUSD-USDT order_levels to 0

### DIFF
--- a/bots/jusd-usdt-dev/conf/strategies/jusd-usdt-conf_pure_mm.yml
+++ b/bots/jusd-usdt-dev/conf/strategies/jusd-usdt-conf_pure_mm.yml
@@ -76,7 +76,7 @@ inventory_range_multiplier: 1.0
 inventory_price: 1.0
 
 # Number of levels of orders to place on each side of the order book.
-order_levels: 61
+order_levels: 0 ## IMPORTANT TODO: change to 60 , 0 is for turning off the strategy
 
 # Increase or decrease size of consecutive orders after the first order (if order_levels > 1).
 order_level_amount: 0


### PR DESCRIPTION
## Summary
- Update `bots/jusd-usdt-dev/conf/strategies/jusd-usdt-conf_pure_mm.yml` to set `order_levels: 0`.
- Keep this as a config-level toggle for disabling new custom MM quote levels in this bot profile.

## Test plan
- [x] Validate config change is applied in branch diff
- [ ] Deploy and verify the bot does not create new non-hanging orders while `order_levels` is 0