### PR TITLE
Hotfix: entrypoint crashes when SCRIPT_FILE is not set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ fi
 
 # Start Hummingbot with the strategy
 strategyFile=`printenv STRATEGY_FILE`
-scriptFile=`printenv SCRIPT_FILE`
+scriptFile=`printenv SCRIPT_FILE` || true
 
 if [[ ! -z $strategyFile ]]
 then


### PR DESCRIPTION
## Summary
`printenv SCRIPT_FILE` exits with code 1 when the variable is not set. With `set -e`, this causes the entrypoint to abort before launching hummingbot, breaking all existing bots that don't set `SCRIPT_FILE`.

## Fix
Add `|| true` so the exit code is always 0 regardless of whether the variable is set.