### PR TITLE
Fix keep_market_pmm sell/buy executor creation order

### DIFF
--- a/controllers/custom/keep_market_pmm.py
+++ b/controllers/custom/keep_market_pmm.py
@@ -196,8 +196,8 @@ class KeepMarketPMM(ControllerBase):
             execution_strategy=ExecutionStrategy.LIMIT,
             controller_id=self.config.id,
         )
-        actions.append(CreateExecutorAction(controller_id=self.config.id, executor_config=buy_config))
         actions.append(CreateExecutorAction(controller_id=self.config.id, executor_config=sell_config))
+        actions.append(CreateExecutorAction(controller_id=self.config.id, executor_config=buy_config))
 
         return actions
 


### PR DESCRIPTION
## Summary
- Swap sell and buy executor creation order so sell is appended before buy

## Test plan
- [ ] Deploy keep-market bot and verify orders are placed correctly