### PR TITLE
Fix order_refresh_tolerance_pct exceeding bid_spread

### DIFF
--- a/bots/deuro-usdt-dev/conf/strategies/deuro-usdt-conf_pure_mm.yml
+++ b/bots/deuro-usdt-dev/conf/strategies/deuro-usdt-conf_pure_mm.yml
@@ -36,7 +36,7 @@ max_order_age: 86400.0
 
 # The spread (from mid price) to defer order refresh process to the next cycle.
 # (Enter 1 to indicate 1%), value below 0, e.g. -1, is to disable this feature - not recommended.
-order_refresh_tolerance_pct: 0.21
+order_refresh_tolerance_pct: 0.05
 
 # Size of your bid and ask order.
 order_amount: 150.0

--- a/bots/deuro-usdt/conf/strategies/deuro-usdt-conf_pure_mm.yml
+++ b/bots/deuro-usdt/conf/strategies/deuro-usdt-conf_pure_mm.yml
@@ -36,7 +36,7 @@ max_order_age: 86400.0
 
 # The spread (from mid price) to defer order refresh process to the next cycle.
 # (Enter 1 to indicate 1%), value below 0, e.g. -1, is to disable this feature - not recommended.
-order_refresh_tolerance_pct: 0.21
+order_refresh_tolerance_pct: 0.05
 
 # Size of your bid and ask order.
 order_amount: 150.0


### PR DESCRIPTION
## Problem

The `order_refresh_tolerance_pct` (0.21%) was configured **higher** than the `bid_spread` (0.20%) in both the prod and dev dEURO-USDT bot configs. This creates a window where the bot actively loses money on trades.

### How this causes losses

The bot uses a custom API price source (CoinGecko EUR/USDT via `api.deuro.com/prices/eur`) and places bid orders at `reference_price × (1 - bid_spread)` = 0.2% below the EUR/USDT mid price.

The `order_refresh_tolerance_pct` controls when the bot refreshes its orders: if the newly calculated order price differs from the existing order price by **less than** the tolerance, the bot skips the refresh and keeps the stale order on the book.

With tolerance (0.21%) > spread (0.20%), the following happens:

1. Bot places bid at `ref × 0.998` (0.2% below fair value) — correct
2. EUR/USD drops by e.g. 0.20% — fair value is now `new_ref`
3. Old bid is now **at or above** the new fair value (`old_ref × 0.998 ≈ new_ref`)
4. Tolerance check: price change (0.20%) < tolerance (0.21%) → **no refresh!**
5. Someone sells into the stale bid → bot buys dEURO at ≥ 1.00 EUR → **loss**

| EUR/USD drop | Refresh triggered? | EUR cost per dEURO | Result |
|---|---|---|---|
| 0.10% | No (< 0.21%) | 0.999 | Profit 0.1% |
| 0.15% | No (< 0.21%) | 0.9995 | Profit 0.05% |
| **0.20%** | **No (< 0.21%)** | **1.0000** | **Break-even** |
| **0.205%** | **No (< 0.21%)** | **1.00005** | **Loss** |
| 0.21% | Yes (= 0.21%) | — | Refresh → 0.2% profit |

The critical code path is in `custom_market_making.pyx:1231-1240`:

```python
cdef bint c_is_within_tolerance(self, list current_prices, list proposal_prices):
    for current, proposal in zip(current_prices, proposal_prices):
        if abs(proposal - current)/current > self._order_refresh_tolerance_pct:
            return False
    return True  # within tolerance → orders NOT refreshed
```

Both values are divided by 100 in `start.py` before being passed to the strategy, so config value 0.21 becomes 0.0021 (0.21%) and 0.2 becomes 0.002 (0.20%) in the code.

### Evidence from trade data

Analysis of the XT spot trading history (2026-03-09) shows 8 real dEURO/USDT buy trades. While most trades achieved a small discount (~0.2% below peg), the narrow gap between tolerance and spread means any EUR/USD movement of 0.20–0.21% within a refresh cycle results in break-even or loss-making fills.

## Fix

Reduce `order_refresh_tolerance_pct` from `0.21` to `0.05` in both configs:

- `bots/deuro-usdt/conf/strategies/deuro-usdt-conf_pure_mm.yml` (prod)
- `bots/deuro-usdt-dev/conf/strategies/deuro-usdt-conf_pure_mm.yml` (dev)

This ensures a minimum safety margin of **0.15%** (= 0.20% spread − 0.05% tolerance) on every trade, even when prices move within the tolerance window. The bot will refresh orders slightly more frequently (on >0.05% price changes instead of >0.21%), which is acceptable given the 15-second `order_refresh_time`.

## Rule of thumb

`order_refresh_tolerance_pct` should always be **significantly smaller** than `bid_spread` to preserve the intended profit margin. A good ratio is tolerance ≤ 25% of spread.