### PR TITLE
Improve keep_market_pmm order placement using mid price with drift guard

### DIFF
--- a/bots/keep-market-dev/conf/controllers/conf_keep_market_deps_usdt.yml
+++ b/bots/keep-market-dev/conf/controllers/conf_keep_market_deps_usdt.yml
@@ -12,3 +12,4 @@ order_amount_quote: '10'
 price_source: custom_api
 price_source_custom_api: https://api.deuro.com/prices/deps
 custom_api_quote_key: usd
+reference_price_drift_percentage: '0.002'

--- a/bots/keep-market-dev/conf/controllers/conf_keep_market_deuro_usdt.yml
+++ b/bots/keep-market-dev/conf/controllers/conf_keep_market_deuro_usdt.yml
@@ -12,3 +12,4 @@ order_amount_quote: '10'
 price_source: custom_api
 price_source_custom_api: https://api.deuro.com/prices/eur
 custom_api_quote_key: usd
+reference_price_drift_percentage: '0.002'

--- a/bots/keep-market/conf/controllers/conf_keep_market_deps_usdt.yml
+++ b/bots/keep-market/conf/controllers/conf_keep_market_deps_usdt.yml
@@ -12,3 +12,4 @@ order_amount_quote: '10'
 price_source: custom_api
 price_source_custom_api: https://api.deuro.com/prices/deps
 custom_api_quote_key: usd
+reference_price_drift_percentage: '0.002'

--- a/bots/keep-market/conf/controllers/conf_keep_market_deuro_usdt.yml
+++ b/bots/keep-market/conf/controllers/conf_keep_market_deuro_usdt.yml
@@ -12,3 +12,4 @@ order_amount_quote: '10'
 price_source: custom_api
 price_source_custom_api: https://api.deuro.com/prices/eur
 custom_api_quote_key: usd
+reference_price_drift_percentage: '0.002'

--- a/controllers/custom/keep_market_pmm.py
+++ b/controllers/custom/keep_market_pmm.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import aiohttp
 from pydantic import Field
 
-from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.common import PriceType, TradeType
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
@@ -20,10 +20,11 @@ class KeepMarketPMMConfig(ControllerConfigBase):
     order_amount_quote: Decimal = Field(default=Decimal("100"), description="Quote amount per order")
     update_interval: float = Field(default=8.0, description="Update interval in seconds")
     candles_config: List[CandlesConfig] = []
-    price_source: str = Field(default="current_market", description="Price source: current_market | custom_api | fixed_price")
+    price_source: str = Field(default="custom_api", description="Price source: custom_api | fixed_price")
     price_source_custom_api: Optional[str] = Field(default=None, description="URL for custom API price source")
     custom_api_quote_key: str = Field(default="usd", description="JSON key to extract price from custom API response")
     price_source_fixed_price: Optional[Decimal] = Field(default=None, description="Fixed reference price")
+    reference_price_drift_percentage: Decimal = Field(default=Decimal("0.002"), description="Max allowed drift between reference and mid price (e.g. 0.002 = 0.2%)")
 
     def update_markets(self, markets):
         return markets.add_or_update(self.trading_connector, self.trading_pair)
@@ -46,7 +47,10 @@ class KeepMarketPMM(ControllerBase):
         self.config: KeepMarketPMMConfig = config
 
         self.processed_data = {
-            "last_bid": None,
+            "reference_price": None,
+            "mid_price": None,
+            "best_bid": None,
+            "best_ask": None,
             "last_candle": None,
         }
 
@@ -73,14 +77,37 @@ class KeepMarketPMM(ControllerBase):
         try:
             reference_price = await self.fetch_reference_price()
             if reference_price is None:
-                self.logger().warning("Price source unavailable, skipping cycle")
-            self.processed_data["last_bid"] = reference_price
+                self.logger().warning(f"----> {self.config.trading_pair} reference_price unavailable")
+
+            mid_price = self.market_data_provider.get_price_by_type(
+                connector_name=self.config.trading_connector,
+                trading_pair=self.config.trading_pair,
+                price_type=PriceType.MidPrice
+            )
+            best_bid = self.market_data_provider.get_price_by_type(
+                connector_name=self.config.trading_connector,
+                trading_pair=self.config.trading_pair,
+                price_type=PriceType.BestBid
+            )
+            best_ask = self.market_data_provider.get_price_by_type(
+                connector_name=self.config.trading_connector,
+                trading_pair=self.config.trading_pair,
+                price_type=PriceType.BestAsk
+            )
+            self.logger().info(f"----> {self.config.trading_pair} best_bid={best_bid} best_ask={best_ask} mid_price={mid_price} reference_price={reference_price}")
+            self.processed_data["reference_price"] = reference_price
+            self.processed_data["mid_price"] = mid_price
+            self.processed_data["best_bid"] = best_bid
+            self.processed_data["best_ask"] = best_ask
 
             await self.fetch_candle_data()
 
         except Exception as e:
             self.logger().error(f"Error updating processed data: {e}")
-            self.processed_data["last_bid"] = None
+            self.processed_data["reference_price"] = None
+            self.processed_data["mid_price"] = None
+            self.processed_data["best_bid"] = None
+            self.processed_data["best_ask"] = None
 
     async def fetch_candle_data(self):
         try:
@@ -166,10 +193,29 @@ class KeepMarketPMM(ControllerBase):
         return actions
 
     def get_order_actions(self):
-        price = self.processed_data.get("last_bid")
+        reference_price = self.processed_data.get("reference_price")
+        mid_price = self.processed_data.get("mid_price")
 
-        if price is None or price <= 0:
+        if reference_price is None or reference_price <= 0:
+            self.logger().warning(f"----> {self.config.trading_pair} reference_price unavailable, skipping order")
             return []
+        if mid_price is None or mid_price <= 0:
+            self.logger().warning(f"----> {self.config.trading_pair} mid_price unavailable, skipping order")
+            return []
+
+        best_bid = self.processed_data.get("best_bid")
+        best_ask = self.processed_data.get("best_ask")
+        if best_bid is None or best_ask is None or best_bid >= best_ask:
+            self.logger().warning(f"----> {self.config.trading_pair} no spread (best_bid={best_bid} best_ask={best_ask}), skipping order")
+            return []
+
+        drift = abs(mid_price - reference_price) / reference_price
+        if drift <= self.config.reference_price_drift_percentage:
+            price = mid_price
+            self.logger().info(f"----> {self.config.trading_pair} mid_price within drift ({drift:.2%}), using mid_price={price}")
+        else:
+            price = reference_price
+            self.logger().info(f"----> {self.config.trading_pair} mid_price outside drift ({drift:.2%}), using reference_price={price}")
 
         fraction = Decimal(str(random.uniform(0.75, 1.0)))
         amount = (self.config.order_amount_quote * fraction) / price
@@ -202,8 +248,9 @@ class KeepMarketPMM(ControllerBase):
         return actions
 
     def to_format_status(self):
-        price = self.processed_data.get("last_bid")
-        return [f"KeepMarketPMM price={price} q={self.config.order_amount_quote}"]
+        reference_price = self.processed_data.get("reference_price")
+        mid_price = self.processed_data.get("mid_price")
+        return [f"KeepMarketPMM reference_price={reference_price} mid_price={mid_price} q={self.config.order_amount_quote}"]
 
     async def control_task(self):
         connector_ready = any(connector.ready for connector in self.market_data_provider.connectors.values())


### PR DESCRIPTION
## Summary

- Fetch `mid_price`, `best_bid` and `best_ask` from the exchange order book each cycle
- Add `reference_price_drift_percentage` param (default 0.2%): use `mid_price` when within drift of `reference_price`, otherwise fall back to `reference_price`
- Skip order placement when no spread exists (`best_bid >= best_ask`) to avoid queue competition with third-party orders
- Rename misleading `last_bid` key to `reference_price` throughout
- Remove `current_market` as a valid `price_source` option (was silently returning `None`)
- Update all bot config files with `reference_price_drift_percentage: 0.002`

## Test plan

- [ ] Deploy to keep-market-dev and verify logs show `best_bid`, `best_ask`, `mid_price` and `reference_price` each cycle
- [ ] Confirm orders are placed using `mid_price` when drift is within 0.2%
- [ ] Confirm orders fall back to `reference_price` when drift exceeds threshold
- [ ] Confirm orders are skipped and warning logged when spread is zero