### PR TITLE
Fix control loop hang caused by missing aiohttp timeout

### DIFF
--- a/controllers/custom/keep_market_pmm.py
+++ b/controllers/custom/keep_market_pmm.py
@@ -64,7 +64,8 @@ class KeepMarketPMM(ControllerBase):
             return self.config.price_source_fixed_price
         if self.config.price_source == "custom_api":
             try:
-                async with aiohttp.ClientSession() as session:
+                timeout = aiohttp.ClientTimeout(total=5)
+                async with aiohttp.ClientSession(timeout=timeout) as session:
                     async with session.get(self.config.price_source_custom_api) as resp:
                         data = await resp.json()
                         return Decimal(str(data[self.config.custom_api_quote_key]))


### PR DESCRIPTION
## Summary
- The `fetch_reference_price` custom API call had no timeout, causing the controller's `control_task` coroutine to block indefinitely when the network was disrupted
- This was triggered by a WS user stream disconnection at 2026-03-15 01:14:36 which caused the aiohttp request to hang, freezing the entire control loop permanently and stopping all order placement
- Added `aiohttp.ClientTimeout(total=5)` to the custom API session so the request times out in 5 seconds, logs an error, and the loop continues normally

## Test plan
- [ ] Restart the bot and verify orders resume being placed
- [ ] Simulate a network disruption and confirm the bot recovers within ~5 seconds instead of hanging