### PR TITLE
Improve XT user-stream readiness recovery after reconnect

### DIFF
--- a/hummingbot/connector/exchange/xt/xt_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/xt/xt_api_user_stream_data_source.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import TYPE_CHECKING, Any, List, Optional
 
 from hummingbot.connector.exchange.xt import xt_constants as CONSTANTS, xt_web_utils as web_utils
@@ -30,6 +31,12 @@ class XtAPIUserStreamDataSource(UserStreamTrackerDataSource):
         self._current_listen_key = None
         self._domain = domain
         self._api_factory = api_factory
+        self._last_stream_ready_time = 0.0
+
+    @property
+    def last_recv_time(self) -> float:
+        # Consider the stream initialized once we successfully connect and subscribe.
+        return max(super().last_recv_time, self._last_stream_ready_time)
 
     async def listen_for_user_stream(self, output: asyncio.Queue):
         """
@@ -46,6 +53,7 @@ class XtAPIUserStreamDataSource(UserStreamTrackerDataSource):
                 self.logger().info(f"Fetched XT listenKey: {self._current_listen_key}")
                 await self._subscribe_channels(websocket_assistant=self._ws_assistant)
                 self.logger().info("Subscribed to private account and orders channels...")
+                self._last_stream_ready_time = time.time()
                 # Start background ping loop
                 self._ping_task = asyncio.create_task(self._send_raw_ping(self._ws_assistant))
                 await self._process_websocket_messages(websocket_assistant=self._ws_assistant, queue=output)
@@ -53,7 +61,7 @@ class XtAPIUserStreamDataSource(UserStreamTrackerDataSource):
                 raise
             except Exception:
                 self.logger().exception("Unexpected error while listening to user stream. Retrying after 5 seconds...")
-                await self._sleep(1.0)
+                await self._sleep(5.0)
             finally:
                 await self._on_user_stream_interruption(websocket_assistant=self._ws_assistant)
                 self._ws_assistant = None
@@ -128,6 +136,7 @@ class XtAPIUserStreamDataSource(UserStreamTrackerDataSource):
     async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
         await super()._on_user_stream_interruption(websocket_assistant=websocket_assistant)
         self._current_listen_key = None
+        self._last_stream_ready_time = 0.0
 
     async def _send_raw_ping(self, ws: WSAssistant):
         """Send a raw 'ping' string every WS_HEARTBEAT_TIME_INTERVAL seconds."""


### PR DESCRIPTION
## Summary
- mark XT private user-stream as ready immediately after successful websocket subscribe so connector readiness can recover promptly after reconnects
- clear the readiness marker on interruption to avoid stale ready state
- align retry sleep with the logged backoff message (5 seconds)

## Test plan
- [ ] Run bot on XT and force websocket disconnect/reconnect cycle
- [ ] Verify controller resumes order decisions after reconnect without manual restart
- [ ] Confirm readiness drops on interruption and returns after subscribe