### PR TITLE
Increase JUSD keep-market config quote amounts to 100

### DIFF
--- a/bots/keep-market-dev/conf/controllers/conf_keep_market_jusd_usdt.yml
+++ b/bots/keep-market-dev/conf/controllers/conf_keep_market_jusd_usdt.yml
@@ -1,14 +1,14 @@
 id: keep_market_pmm_3
 controller_name: keep_market_pmm
 controller_type: custom
-total_amount_quote: '10'
+total_amount_quote: '100'
 manual_kill_switch: false
 candles_config: []
 initial_positions: []
 update_interval: 15.0
 trading_connector: xt
 trading_pair: JUSD-USDT
-order_amount_quote: '10'
+order_amount_quote: '100'
 price_source: fixed_price
 price_source_custom_api: null
 custom_api_quote_key: usd


### PR DESCRIPTION
## Summary
- update `conf_keep_market_jusd_usdt.yml` to increase `total_amount_quote` from `10` to `100`
- update `order_amount_quote` from `10` to `100`
- keep the rest of the controller configuration unchanged

## Test plan
- [ ] Start keep-market-dev bot with this config
- [ ] Confirm JUSD controller loads expected quote sizing
- [ ] Verify newly created orders use the updated amount scale