### PR TITLE
Handle cancelled ping task during XT user-stream cleanup

### DIFF
--- a/hummingbot/connector/exchange/xt/xt_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/xt/xt_api_user_stream_data_source.py
@@ -69,6 +69,8 @@ class XtAPIUserStreamDataSource(UserStreamTrackerDataSource):
                     self._ping_task.cancel()
                     try:
                         await self._ping_task
+                    except asyncio.CancelledError:
+                        pass
                     except Exception:
                         pass
 


### PR DESCRIPTION
## Summary
- catch `asyncio.CancelledError` when awaiting the cancelled XT user-stream ping task in cleanup
- prevent the user-stream listener coroutine from terminating during websocket interruption cleanup
- allow the reconnect loop to continue after user-stream disconnections instead of silently stopping

## Test plan
- [ ] Run keep-market bot on XT and trigger websocket interruption
- [ ] Verify user-stream logs continue showing reconnect attempts after interruption
- [ ] Confirm controller ticks and order creation resume without manual restart