### PR TITLE
Reduce JUSD keep-market config quote amounts to 20

### DIFF
--- a/bots/keep-market-dev/conf/controllers/conf_keep_market_jusd_usdt.yml
+++ b/bots/keep-market-dev/conf/controllers/conf_keep_market_jusd_usdt.yml
@@ -1,14 +1,14 @@
 id: keep_market_pmm_3
 controller_name: keep_market_pmm
 controller_type: custom
-total_amount_quote: '100'
+total_amount_quote: '20'
 manual_kill_switch: false
 candles_config: []
 initial_positions: []
 update_interval: 15.0
 trading_connector: xt
 trading_pair: JUSD-USDT
-order_amount_quote: '100'
+order_amount_quote: '20'
 price_source: fixed_price
 price_source_custom_api: null
 custom_api_quote_key: usd


### PR DESCRIPTION
## Summary
- update `conf_keep_market_jusd_usdt.yml` to reduce `total_amount_quote` from `100` to `20`
- update `order_amount_quote` from `100` to `20`
- keep all other controller settings unchanged

## Test plan
- [ ] Start keep-market-dev bot using this config
- [ ] Verify JUSD controller reports the new quote sizing
- [ ] Confirm created JUSD orders use the reduced amount scale